### PR TITLE
Do not check if macOS uses an Intel CPU

### DIFF
--- a/Formula/kcctl.rb
+++ b/Formula/kcctl.rb
@@ -8,7 +8,7 @@ class Kcctl < Formula
     url "https://github.com/kcctl/kcctl/releases/download/v1.0.0.Alpha5/kcctl-1.0.0.Alpha5-linux-x86_64.zip"
     sha256 "669006978af4599da25221fbeaabf6cd956061238a3a1ab452435f0b574d16a8"
   end
-  if OS.mac? && Hardware::CPU.intel?
+  if OS.mac?
     url "https://github.com/kcctl/kcctl/releases/download/v1.0.0.Alpha5/kcctl-1.0.0.Alpha5-osx-x86_64.zip"
     sha256 "562e59dd6890567492eb4f43a2dc64c45caf78d7f7794039a1a179c0e7af9fbb"
   end


### PR DESCRIPTION
This fixes https://github.com/kcctl/kcctl/issues/134.

See also https://github.com/kcctl/kcctl/issues/245. Although SDKMAN! requires an additional fix.