### PR TITLE
Allow installation on non-Intel CPUs with MacOS, and improve error message for unsupported environments

### DIFF
--- a/Formula/kcctl.rb
+++ b/Formula/kcctl.rb
@@ -7,12 +7,13 @@ class Kcctl < Formula
   if OS.linux? && Hardware::CPU.intel?
     url "https://github.com/kcctl/kcctl/releases/download/v1.0.0.Alpha5/kcctl-1.0.0.Alpha5-linux-x86_64.zip"
     sha256 "669006978af4599da25221fbeaabf6cd956061238a3a1ab452435f0b574d16a8"
-  end
-  if OS.mac? && Hardware::CPU.intel?
+  elsif OS.mac?
+    # TODO: Check for Rosetta if not running on an Intel CPU?
     url "https://github.com/kcctl/kcctl/releases/download/v1.0.0.Alpha5/kcctl-1.0.0.Alpha5-osx-x86_64.zip"
     sha256 "562e59dd6890567492eb4f43a2dc64c45caf78d7f7794039a1a179c0e7af9fbb"
+  else
+    raise RuntimeError.new("kcctl is only supported on Linux (with Intel CPU) or MacOS")
   end
-
 
   def install
     libexec.install Dir["*"]


### PR DESCRIPTION
Addresses https://github.com/kcctl/kcctl/issues/134

Adapted from https://github.com/kcctl/homebrew-tap/pull/3